### PR TITLE
Add admin authentication and restructure DTO/HTTPResource namespaces

### DIFF
--- a/.idea/laravel-idea.xml
+++ b/.idea/laravel-idea.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="InertiaPackage">
+    <option name="directoryPaths">
+      <list />
+    </option>
+  </component>
+</project>

--- a/src/Controller/BeerController.php
+++ b/src/Controller/BeerController.php
@@ -2,10 +2,10 @@
 
 namespace App\Controller;
 
-use App\DTO\CreateBeerDTO;
-use App\DTO\UpdateBeerDTO;
+use App\DTO\Beer\CreateBeerDTO;
+use App\DTO\Beer\UpdateBeerDTO;
 use App\Entity\Beer;
-use App\HTTPResource\Beer\BeerResource;
+use App\HTTPResource\MobileAPI\Beer\BeerResource;
 use App\Repository\BeerRepository;
 use App\Request\Beer\CreateBeerRequest;
 use App\Request\Beer\UpdateBeerRequest;

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -2,9 +2,9 @@
 
 namespace App\Controller;
 
-use App\DTO\LoginDTO;
-use App\DTO\UserCreateDTO;
-use App\HTTPResource\Auth\AuthResource;
+use App\DTO\Auth\LoginDTO;
+use App\DTO\User\UserCreateDTO;
+use App\HTTPResource\MobileAPI\Auth\AuthResource;
 use App\Request\Auth\LoginRequest;
 use App\Request\Auth\RegistrationRequest;
 use App\Service\UserService;
@@ -37,4 +37,18 @@ class UserController extends BaseController
 
         return $this->successResponse(new AuthResource($authData));
     }
+
+    #[Route('/admin/login', name: 'admin_login', methods: ['POST'])]
+    public function adminLogin(UserService $userService, LoginRequest $request): JsonResponse
+    {
+        $data = $request->getRequest()->toArray();
+        try {
+            $authData = $userService->adminLogin(new LoginDTO($data['name'], $data['password']));
+        } catch (NotFoundHttpException|BadRequestHttpException $exception) {
+            return $this->errorResponse($exception->getMessage(), (array)$exception->getMessage(), $exception->getStatusCode());
+        }
+
+        return $this->successResponse(new AuthResource($authData));
+    }
 }
+

--- a/src/DTO/Auth/AuthDTO.php
+++ b/src/DTO/Auth/AuthDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\DTO;
+namespace App\DTO\Auth;
 
 use App\Entity\User;
 

--- a/src/DTO/Auth/LoginDTO.php
+++ b/src/DTO/Auth/LoginDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\DTO;
+namespace App\DTO\Auth;
 
 class LoginDTO
 {

--- a/src/DTO/Beer/CreateBeerDTO.php
+++ b/src/DTO/Beer/CreateBeerDTO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\DTO;
+namespace App\DTO\Beer;
 
 class CreateBeerDTO
 {

--- a/src/DTO/Beer/UpdateBeerDTO.php
+++ b/src/DTO/Beer/UpdateBeerDTO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\DTO;
+namespace App\DTO\Beer;
 
 class UpdateBeerDTO
 {

--- a/src/DTO/User/UserCreateDTO.php
+++ b/src/DTO/User/UserCreateDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\DTO;
+namespace App\DTO\User;
 
 class UserCreateDTO
 {

--- a/src/DataFixtures/AdminFixture.php
+++ b/src/DataFixtures/AdminFixture.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class AdminFixture extends Fixture
+{
+    private UserPasswordHasherInterface $passwordHasher;
+
+    public function __construct(UserPasswordHasherInterface $passwordHasher)
+    {
+        $this->passwordHasher = $passwordHasher;
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $admin = new User();
+        $admin->setName('admin');
+        $admin->setEmail('admin@admin.com');
+        $admin->setIsAdmin(true);
+        $admin->setPassword(
+            $this->passwordHasher->hashPassword($admin, 'password')
+        );
+
+        $manager->persist($admin);
+        $manager->flush();
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -29,6 +29,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 255)]
     private ?string $password = null;
 
+    #[ORM\Column(type: 'boolean')]
+    private bool $is_admin = false;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -90,5 +93,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setPassword(string $password): void
     {
         $this->password = $password;
+    }
+
+    public function getIsAdmin(): bool
+    {
+        return $this->is_admin;
+    }
+
+    public function setIsAdmin(bool $is_admin): void
+    {
+        $this->is_admin = $is_admin;
     }
 }

--- a/src/HTTPResource/AdminPage/Auth/AdminAuthResource.php
+++ b/src/HTTPResource/AdminPage/Auth/AdminAuthResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\HTTPResource\AdminPage\Auth;
+
+use App\DTO\Auth\AuthDTO;
+use App\HTTPResource\HTTPResource;
+
+class AdminAuthResource extends HTTPResource
+{
+    public function toArray(): array
+    {
+        return [
+            'token' => $this->entity->token,
+            'user' => [
+                'id' => $this->entity->user->getId(),
+                'name' => $this->entity->user->getName(),
+                'email' => $this->entity->user->getEmail(),
+            ],
+        ];
+    }
+
+    public function expectedClass(): string
+    {
+        return AuthDTO::class;
+    }
+}

--- a/src/HTTPResource/MobileAPI/Auth/AuthResource.php
+++ b/src/HTTPResource/MobileAPI/Auth/AuthResource.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\HTTPResource\Auth;
+namespace App\HTTPResource\MobileAPI\Auth;
 
-use App\DTO\AuthDTO;
+use App\DTO\Auth\AuthDTO;
 use App\HTTPResource\HTTPResource;
-use App\HTTPResource\User\UserResource;
+use App\HTTPResource\MobileAPI\User\UserResource;
 
 class AuthResource extends HTTPResource
 {

--- a/src/HTTPResource/MobileAPI/Beer/BeerResource.php
+++ b/src/HTTPResource/MobileAPI/Beer/BeerResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\HTTPResource\Beer;
+namespace App\HTTPResource\MobileAPI\Beer;
 
 use App\Entity\Beer;
 use App\HTTPResource\HTTPResource;

--- a/src/HTTPResource/MobileAPI/User/UserResource.php
+++ b/src/HTTPResource/MobileAPI/User/UserResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\HTTPResource\User;
+namespace App\HTTPResource\MobileAPI\User;
 
 use App\Entity\User;
 use App\HTTPResource\HTTPResource;

--- a/src/Service/BeerService.php
+++ b/src/Service/BeerService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Service;
 
-use App\DTO\CreateBeerDTO;
-use App\DTO\UpdateBeerDTO;
+use App\DTO\Beer\CreateBeerDTO;
+use App\DTO\Beer\UpdateBeerDTO;
 use App\Entity\Beer;
 use App\Repository\BeerRepository;
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -2,9 +2,9 @@
 
 namespace App\Service;
 
-use App\DTO\AuthDTO;
-use App\DTO\LoginDTO;
-use App\DTO\UserCreateDTO;
+use App\DTO\Auth\AuthDTO;
+use App\DTO\Auth\LoginDTO;
+use App\DTO\User\UserCreateDTO;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
@@ -51,5 +51,14 @@ class UserService
             $this->jwtManager->create($user),
             $user
         );
+    }
+
+    public function adminLogin(LoginDTO $loginDTO): AuthDTO
+    {
+        $authData = $this->login($loginDTO);
+        if (!$authData->user->getIsAdmin()) {
+            throw new BadRequestHttpException('User is not admin.');
+        }
+        return $authData;
     }
 }


### PR DESCRIPTION
- Added `adminLogin` endpoint and service method with admin check
- Introduced `is_admin` field in `User` entity and `AdminFixture` to create admin user
- Moved DTOs and HTTPResources into structured `Auth`, `User`, `Beer`, and `MobileAPI` namespaces